### PR TITLE
Bump external dns version

### DIFF
--- a/apps_external_dns.tf
+++ b/apps_external_dns.tf
@@ -38,7 +38,7 @@ resource "helm_release" "external_dns" {
   name       = "external-dns"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "external-dns"
-  version    = "5.4.8"
+  version    = "6.2.1"
 
   namespace = kubernetes_namespace.external_dns[0].metadata[0].name
 


### PR DESCRIPTION
So, it turns out that `external-dns` `5.4.8` doesn't work with AKS `1.22`.