### PR TITLE
Fix upgrade_override block bug

### DIFF
--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -85,6 +85,11 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
   tags = local.tags
 
+  # Do not remove! Once set, upgrade_override block cannot be removed from state.
+  upgrade_override {
+    force_upgrade_enabled = false
+  }
+
   depends_on = [
     azurerm_role_assignment.service_contributor
   ]


### PR DESCRIPTION
Unfortunately we ran into one of these bugs. :stuck_out_tongue:
See note on upgrade_override block: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#upgrade_override-1.

I don't think we'd ever like to set `force_upgrade_enabled` to `true`, so there is no variable for it. If you feel otherwise, let me know.