### PR TITLE
Fix force replacements due to node resource group unknown at apply

### DIFF
--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -2,6 +2,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   name                = "${var.prefix}-k8s-cluster"
   resource_group_name = azurerm_resource_group.cluster.name
   location            = azurerm_resource_group.cluster.location
+  node_resource_group = local.node_resource_group
 
   dns_prefix         = var.prefix
   kubernetes_version = var.cluster_version
@@ -127,6 +128,5 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 }
 
 data "azurerm_resource_group" "cluster_node_group" {
-  name = azurerm_kubernetes_cluster.cluster.node_resource_group
+  name = local.node_resource_group
 }
-

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -25,4 +25,8 @@ locals {
   tags = merge(var.tags, {
     cluster_name = var.prefix
   })
+
+  cluster_name        = "${var.prefix}-k8s-cluster"
+  normalized_location = lower(replace(var.resource_group.location, " ", ""))
+  node_resource_group = "MC_${var.resource_group.name}_${local.cluster_name}_${local.normalized_location}"
 }

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -28,5 +28,5 @@ locals {
 
   cluster_name        = "${var.prefix}-k8s-cluster"
   normalized_location = lower(replace(var.resource_group.location, " ", ""))
-  node_resource_group = "MC_${var.resource_group.name}_${local.cluster_name}_${local.normalized_location}"
+  node_resource_group = coalesce(var.node_resource_group, "MC_${var.resource_group.name}_${local.cluster_name}_${local.normalized_location}")
 }

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -162,3 +162,9 @@ variable "automatic_upgrade_channel" {
   }
 }
 
+variable "node_resource_group" {
+  description = "Override for the node resource group name. If not set, defaults to MC_{resource_group}_{cluster_name}_{location}."
+  type        = string
+  default     = null
+}
+


### PR DESCRIPTION
Fix for PITA `aad_managed_identity_operator` and `aad_vm_contributor` force replacements in plan on cluster changes. 
When ANY changes were planned to the AKS cluster, `node_resource_group` became `(known after apply)` → the resource group data source refreshed → scope became unknown → forced replacement of role assignments.