### PR TITLE
Make upgrade override configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@ terraform-kubernetes-cluster
 
 An all-in-one solution for AKS cluster. Used internally at LeanCode.
 
+## Managing helm releases
+
+See [docs/managing-helm-releases.md](docs/managing-helm-releases.md).
+
+## Known issues
+
+### AzureRM `upgrade_override.effective_until` bug
+
+AzureRM provider 4.x may fail to update AKS when `upgrade_override` is rendered without `effective_until`, because it sends an empty timestamp to Azure. See [hashicorp/terraform-provider-azurerm#28960](https://github.com/hashicorp/terraform-provider-azurerm/issues/28960).
+
+For new clusters, set `force_upgrade_override = false` unless you explicitly need the `upgrade_override` block. For existing clusters where this module has already applied the block, keep `force_upgrade_override = true`; removing it can produce a state diff that cannot be applied cleanly.
+
 ## Migrating to kubernetes versioned resource types
 
 Concerns version >= 25.0. Kubernetes provider 3.0 deprecates non-versioned resource types (e.g. `kubernetes_namespace` → `kubernetes_namespace_v1`). Terraform's `moved` block does **not** support changing resource types, so use state commands:
@@ -25,6 +37,3 @@ terraform import module.monitoring.kubernetes_namespace_v1.main monitoring
 | `traefik_ingress`  | `kubernetes_namespace_v1.traefik`      | `traefik`      |
 | `cluster_domain`   | `kubernetes_namespace_v1.external_dns` | `external-dns` |
 
-## Managing helm releases
-
-See [docs/managing-helm-releases.md](docs/managing-helm-releases.md).

--- a/cluster/.trivyignore
+++ b/cluster/.trivyignore
@@ -10,3 +10,10 @@ AVD-AZU-0041
 # but Kubernetes RBAC is still enabled by default. We use Entra ID groups with K8s RBAC.
 AVD-AZU-0042
 
+# MEDIUM: Cluster does not have private cluster enabled.
+# Public API endpoint is intentional for this cluster; API access is restricted separately.
+AVD-AZU-0065
+
+# LOW: Cluster does not have disk encryption set ID configured.
+# Platform-managed encryption is sufficient here; customer-managed DES is not required.
+AVD-AZU-0067

--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -110,9 +110,12 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
   tags = local.tags
 
-  # Do not remove! Once set, upgrade_override block cannot be removed from state.
-  upgrade_override {
-    force_upgrade_enabled = false
+  # Once set, upgrade_override block cannot be removed from state — keep var.force_upgrade_override = true after first apply.
+  dynamic "upgrade_override" {
+    for_each = var.force_upgrade_override ? [1] : []
+    content {
+      force_upgrade_enabled = false
+    }
   }
 
   depends_on = [

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -168,3 +168,9 @@ variable "node_resource_group" {
   default     = null
 }
 
+variable "force_upgrade_override" {
+  description = "Whether to render the upgrade_override block on the cluster. Once set to true and applied, it cannot be set back to false — the block cannot be removed from state."
+  type        = bool
+  default     = true
+}
+


### PR DESCRIPTION
`upgrade_override` with `force_upgrade_enabled = false` is valid only for clusters where this state change has already been done (presumably during setting maintenance window). For fresh new clusters it might not be the case.

It would be better to set default value for `force_upgrade_override` to false, but I don't want to introduce breaking change for now, will try to figure it out soon.

The core issue is described in README.