### PR TITLE
Allow temporary_name_for_rotation on default node pool.

### DIFF
--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -26,6 +26,8 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
     type = "VirtualMachineScaleSets"
 
+    temporary_name_for_rotation = var.default_pool.temporary_name_for_rotation
+
     upgrade_settings {
       drain_timeout_in_minutes      = 10
       node_soak_duration_in_minutes = 0

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -75,6 +75,8 @@ variable "default_pool" {
     min_count            = optional(number),
     max_count            = optional(number),
     count                = optional(number),
+
+    temporary_name_for_rotation = optional(string),
   })
 
   validation {


### PR DESCRIPTION
Enables default pool rotation when Azure requires a temporary pool name.